### PR TITLE
feat(hooks): plug WOZ token-savings drift across session

### DIFF
--- a/agents/code.md
+++ b/agents/code.md
@@ -4,3 +4,15 @@ description: WozCode enhanced coding agent with smart search, batch editing, and
 model: inherit
 disallowedTools: Read, Edit, Write, Grep, Glob, NotebookEdit
 ---
+
+## Output style
+
+Lead with the answer. Skip preambles like "I'll now..." or "Let me..." and skip trailing wrap-ups that restate the diff. Fragments are fine when they're clearer than full sentences.
+
+One short sentence before a tool call is enough — don't narrate intent across multiple lines. After a change, name the file and what changed in a single line; do not summarize the conversation.
+
+No headers, bullet lists, or section dividers for short responses. Reach for structure only when the answer genuinely has multiple parts.
+
+## Tool defaults
+
+Use `mcp__plugin_woz_code__Search` for reading and grepping (combine globs + `content_regex` + `output_mode: "file_paths_with_content"` in one call), `mcp__plugin_woz_code__Edit` for all file edits (batch multiple edits across files into one call), and `mcp__plugin_woz_code__Sql` for DB schema/queries. The built-in Read/Edit/Write/Grep/Glob are disallowed for a reason — the WOZCODE equivalents save tokens on every call.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -100,6 +100,10 @@
           {
             "type": "command",
             "command": "node --no-warnings=ExperimentalWarning ${CLAUDE_PLUGIN_ROOT}/scripts/session-telemetry-hook.js"
+          },
+          {
+            "type": "command",
+            "command": "node --no-warnings=ExperimentalWarning ${CLAUDE_PLUGIN_ROOT}/scripts/postcompact-woz-reactivate.js"
           }
         ]
       }

--- a/scripts/postcompact-woz-reactivate.js
+++ b/scripts/postcompact-woz-reactivate.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// PostCompact re-activation reminder for WOZCODE.
+//
+// After Claude Code compacts the conversation, the model can lose awareness
+// that WOZCODE's MCP tools are active and silently fall back to the built-in
+// Read/Edit/Grep/Glob tools for the rest of the session. That regression
+// invisibly burns tokens that WOZCODE's Search/Edit/Sql were saving.
+//
+// This hook emits a short re-activation message as additionalContext so the
+// model sees the reminder immediately after compaction.
+
+const REACTIVATION_MESSAGE = [
+  'WOZCODE active — token-saving tools remain available after compaction.',
+  '',
+  'Use these for file work, not the built-in equivalents:',
+  '  • mcp__plugin_woz_code__Search  (instead of Read / Grep / Glob)',
+  '  • mcp__plugin_woz_code__Edit    (instead of Edit / Write / NotebookEdit)',
+  '  • mcp__plugin_woz_code__Sql     (for DB schema/queries)',
+  '',
+  'Prefer one combined Search call (globs + content_regex, output_mode="file_paths_with_content") over a Read-after-Grep sequence. Batch multiple edits across files into a single Edit call.',
+].join('\n');
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    if (process.stdin.isTTY) return resolve('');
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(data));
+  });
+}
+
+async function main() {
+  // Drain stdin so Claude Code's hook protocol doesn't block on a closed pipe.
+  await readStdin();
+
+  const payload = {
+    hookSpecificOutput: {
+      hookEventName: 'PostCompact',
+      additionalContext: REACTIVATION_MESSAGE,
+    },
+  };
+
+  process.stdout.write(JSON.stringify(payload));
+}
+
+main().catch(() => {
+  // Fail open — never block the session on a reminder hook.
+  process.exit(0);
+});

--- a/skills/woz-brief/SKILL.md
+++ b/skills/woz-brief/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: woz-brief
+description: "Toggle WOZCODE output verbosity for the current session. /woz-brief lite for fragment-style minimum-token replies, /woz-brief full for normal verbosity. TRIGGER on /woz-brief, 'be brief', 'lite mode', 'full verbosity'."
+allowed-tools: Bash(mkdir *), Bash(node *), Bash(cat *), Bash(printf *)
+---
+
+# WOZ Brief
+
+User-controlled output verbosity for the current session. Layers on top of the always-on terse defaults in the `woz:code` agent — `lite` strips even further, `full` restores normal prose.
+
+## Arguments
+
+- `lite` — maximum brevity. One-line answers when possible.
+- `full` — restore default conversational verbosity.
+- (no arg) — print the current mode.
+
+## Behavior
+
+1. Parse the user's argument (`lite`, `full`, or empty). If empty, read the current value from `${CLAUDE_PROJECT_DIR}/.wozcode/brief-mode` (default: `default`) and report it.
+2. Otherwise, persist the choice so future SessionStart-injected reminders pick it up:
+   ```bash
+   mkdir -p "${CLAUDE_PROJECT_DIR}/.wozcode"
+   printf '%s\n' "<mode>" > "${CLAUDE_PROJECT_DIR}/.wozcode/brief-mode"
+   ```
+3. Acknowledge the switch in one short line (e.g., `brief: lite`) and immediately follow the rules below for the rest of the session.
+
+## Lite mode rules
+
+Apply these for every response until the user switches back to `full`:
+
+- Fragments over sentences. Skip articles when the meaning is clear.
+- No preambles, no transitions, no trailing summaries.
+- One short status line per tool batch — not per tool call.
+- After edits: one line per file (`path: what changed`). No diff recap.
+- Drop courtesy phrases ("Sure!", "Of course", "Let me know if…").
+- Headers/bullets only when the answer has 3+ genuinely distinct parts.
+- Code blocks: minimum needed to answer. No surrounding explanation unless asked.
+
+## Full mode rules
+
+Revert to the default `woz:code` agent voice (already terse — see `agents/code.md`). No extra suppression.
+
+## Persistence
+
+The mode is written to `.wozcode/brief-mode` in the project directory. A SessionStart-injected reminder re-applies it on future sessions so the user does not have to retoggle. If the file is missing, treat the mode as `default` (same as `full`).


### PR DESCRIPTION
  - PostCompact hook re-injects WOZ tool reminder so the model doesn't silently revert to Read/Edit/Grep after compaction
  - code agent gains terse-output defaults (body was empty), trimming prose tokens on every response
  - /woz-brief skill adds opt-in lite|full verbosity toggle persisted to .wozcode/brief-mode