### PR TITLE
Document plugin architecture and risk boundaries

### DIFF
--- a/docs/deepwiki/README.md
+++ b/docs/deepwiki/README.md
@@ -1,0 +1,34 @@
+# WOZCODE Plugin DeepWiki
+
+Mode A, agent-native repository wiki generated from the local workspace. This repository is a prebuilt distribution: readable manifests, agent/skill definitions, and hook routing surround bundled JavaScript, native modules, and WASM. Claims are therefore labeled **OBSERVED**, **INFERRED**, or **UNVERIFIED**.
+
+## Wiki blueprint
+
+| Page | Importance | Focus |
+|---|---|---|
+| [Overview](overview.md) | high | Product purpose, repository shape, host surfaces |
+| [Getting started](getting-started.md) | medium | Installation, authentication, management |
+| [Architecture](architecture.md) | high | Components and deployment topology |
+| [Runtime and data flow](runtime-data-flow.md) | high | MCP tools, agents, hooks, router |
+| [Agents and commands](agents-commands.md) | medium | Agent policy and skill surface |
+| [Configuration, auth, and telemetry](configuration-auth-telemetry.md) | high | Settings, credentials, network/data boundaries |
+| [Testing and operations](testing-operations.md) | medium | Verification, benchmarks, updates, native assets |
+| [Risks and limitations](risks-limitations.md) | high | Reviewability, supply chain, open questions |
+
+## Scope and retrieval notes
+
+- Included: root Claude plugin, nested Codex plugin, manifests, hooks, human-readable agents/skills, router config, thin entrypoints, selected artifacts, and a harmless MCP `initialize`/`tools/list` probe.
+- Excluded from exhaustive reading: vendored `node_modules`, generated chunks, native binaries, WASM internals, PDFs/browser payloads, and full deobfuscation.
+- No persistent vector index was created. Retrieval used file inventory, exact-symbol expansion, entrypoint ranking, focused reads, and one-hop import/config tracing.
+- Repository state examined: Claude release `0.3.87`; nested Codex manifest `0.3.70` ([`.claude-plugin/plugin.json:2-8`](../../.claude-plugin/plugin.json), [`codex/wozcode/.codex-plugin/plugin.json:2-10`](../../codex/wozcode/.codex-plugin/plugin.json)).
+
+## Evidence
+
+- `README.md:1-76` — public purpose, install flow, agents, commands.
+- `.mcp.json:2-16` — Claude MCP process and environment.
+- `hooks/hooks.json:2-115` — Claude lifecycle integration.
+- `codex/wozcode/.mcp.json:2-15` — Codex runtime packaging.
+
+## Related
+
+[Overview](overview.md) · [Architecture](architecture.md) · [Risks and limitations](risks-limitations.md)

--- a/docs/deepwiki/agents-commands.md
+++ b/docs/deepwiki/agents-commands.md
@@ -1,0 +1,45 @@
+---
+id: agents-commands
+importance: medium
+filePaths: [agents/code.md, agents/code-free.md, agents/explore.md, skills/woz/SKILL.md, skills/woz-kb/SKILL.md, skills/woz-feedback/SKILL.md, codex/wozcode/agents/code.toml, codex/wozcode/agents/explore.toml]
+relatedPages: [architecture, runtime-data-flow, testing-operations]
+---
+
+# Agents and Commands
+
+**Summary.** **OBSERVED:** WOZCODE changes tool policy more than model behavior: the main agent inherits the host model but forces MCP file operations, Explore uses Haiku for bounded read-only scans, and the free fallback restores native tools ([`agents/code.md:2-5`](../../agents/code.md), [`agents/explore.md:2-10`](../../agents/explore.md), [`agents/code-free.md:2-5`](../../agents/code-free.md)). Commands are implemented as skills and bundled CLI wrappers rather than a `commands/` directory.
+
+## Agent matrix
+
+| Agent | Model | Allowed intent | Key restriction |
+|---|---|---|---|
+| `woz:code` | inherit | coding, search, edit, SQL | native Read/Edit/Write/Grep/Glob disabled |
+| `woz:explore` | Haiku | fast read-only lookup | no Woz Edit, nested Agent, or native file tools |
+| `woz:code-free` | inherit | fallback when Woz cap is exhausted | Woz Search/Edit/Sql disabled |
+
+Evidence: [`agents/code.md:1-6`](../../agents/code.md), [`agents/explore.md:1-10`](../../agents/explore.md), [`agents/code-free.md:1-6`](../../agents/code-free.md).
+
+## Command surface
+
+The consolidated `/woz` skill covers login, logout, status, settings, update, share, deep review, and benchmark ([`skills/woz/SKILL.md:2-24`](../../skills/woz/SKILL.md)). Focused skills add Recall, savings, feedback, and knowledge-base operations; several legacy skill names are deprecated aliases.
+
+- **Account/config:** login, logout, status, settings ([`skills/woz/SKILL.md:30-180`](../../skills/woz/SKILL.md)).
+- **Delivery:** update and share ([`skills/woz/SKILL.md:182-243`](../../skills/woz/SKILL.md)).
+- **Quality:** seven-persona deep review and paired comparison benchmark ([`skills/woz/SKILL.md:244-379`](../../skills/woz/SKILL.md)).
+- **Knowledge:** reviewer tuning/backtests, architecture fetch, cross-repo planning, query/note/suppress/boost/ingest/refresh/ops ([`skills/woz-kb/SKILL.md:7-21`](../../skills/woz-kb/SKILL.md), [`skills/woz-kb/SKILL.md:81-151`](../../skills/woz-kb/SKILL.md)).
+- **Feedback:** sends bug/feedback context through the Woz CLI ([`skills/woz-feedback/SKILL.md:7-35`](../../skills/woz-feedback/SKILL.md)).
+
+## Host parity
+
+**OBSERVED:** Codex has three TOML agents but a smaller skill set than the Claude root. Its main agent directs file work to Search/Edit and reserves Bash for tests/build/scripts ([`codex/wozcode/agents/code.toml:1-14`](../../codex/wozcode/agents/code.toml)); Explore declares a read-only sandbox ([`codex/wozcode/agents/explore.toml:1-18`](../../codex/wozcode/agents/explore.toml)).
+
+## Evidence
+
+- `agents/*.md` — Claude agent policy.
+- `skills/woz/SKILL.md:2-379` — main command contract.
+- `skills/woz-kb/SKILL.md:7-151` — KB/reviewer workflows.
+- `codex/wozcode/agents/*.toml` — Codex policy surface.
+
+## Related
+
+[Architecture](architecture.md) · [Runtime and data flow](runtime-data-flow.md) · [Testing and operations](testing-operations.md)

--- a/docs/deepwiki/architecture.md
+++ b/docs/deepwiki/architecture.md
@@ -1,0 +1,51 @@
+---
+id: architecture
+importance: high
+filePaths: [.mcp.json, codex/wozcode/.mcp.json, .claude-plugin/marketplace.json, codex/wozcode/.codex-plugin/plugin.json, agents/code.md, agents/code-free.md, agents/explore.md, hooks/hooks.json, codex/wozcode/hooks/hooks.json, servers/code-server.js, skills/woz/SKILL.md, skills/woz-kb/SKILL.md]
+relatedPages: [runtime-data-flow, agents-commands, configuration-auth-telemetry]
+---
+
+# Architecture
+
+**Summary.** **OBSERVED:** Each host launches a Node MCP server over stdio and steers an agent toward Woz tools. Claude adds a broad hook layer and richer command/knowledge/review surface; Codex packages a smaller parallel copy ([`.mcp.json:2-16`](../../.mcp.json), [`codex/wozcode/.mcp.json:2-15`](../../codex/wozcode/.mcp.json)).
+
+## Component topology
+
+**OBSERVED diagram:**
+
+```mermaid
+flowchart LR
+  Host[Claude Code or Codex] --> Agent[Woz agent policy]
+  Agent -->|JSON-RPC over stdio| MCP[Node MCP server]
+  MCP --> Tools[Search / Edit / Recall / Sql]
+  Tools --> Files[(Files, images, PDFs)]
+  Tools --> DB[(Postgres, MySQL, SQLite)]
+  Tools --> Sessions[(Session index)]
+  Host -. lifecycle .-> Hooks[Session / reviewer / telemetry hooks]
+  Skills[Slash-command skills] --> Scripts[Bundled CLI scripts]
+  Scripts --> Auth[Auth, KB, update, review services]
+  Router[Optional router daemon] --> Providers[Model providers]
+```
+
+## Layers
+
+1. **Packaging:** Claude marketplace metadata exposes local plugin `woz` v0.3.87 ([`.claude-plugin/marketplace.json:2-20`](../../.claude-plugin/marketplace.json)). The nested Codex plugin declares `skills` and `mcpServers` at v0.3.70 ([`codex/wozcode/.codex-plugin/plugin.json:2-10`](../../codex/wozcode/.codex-plugin/plugin.json)).
+2. **Agent policy:** the main agent blocks native file tools, the free fallback blocks Woz tools, and Explore is a read-only Haiku worker ([`agents/code.md:2-5`](../../agents/code.md), [`agents/code-free.md:2-5`](../../agents/code-free.md), [`agents/explore.md:2-10`](../../agents/explore.md)).
+3. **MCP runtime:** the root configuration always loads the server and injects host/version/telemetry environment ([`.mcp.json:2-16`](../../.mcp.json)). A runtime probe observed protocol `2025-03-26`, server `code` v0.3.87, and Edit/Recall/Search/Sql; implementation is anchored in the bundled entrypoint ([`servers/code-server.js:3`](../../servers/code-server.js)).
+4. **Lifecycle:** Claude runs bootstrap, reviewer, and telemetry handlers across prompt/tool/stop/compact events ([`hooks/hooks.json:3-113`](../../hooks/hooks.json)). Codex has startup/resume and post-tool hooks ([`codex/wozcode/hooks/hooks.json:3-33`](../../codex/wozcode/hooks/hooks.json)).
+5. **Optional subsystems:** consolidated commands expose review and benchmark; `woz-kb` exposes review tuning, backtests, cross-repo planning, and knowledge operations ([`skills/woz/SKILL.md:244-379`](../../skills/woz/SKILL.md), [`skills/woz-kb/SKILL.md:7-21`](../../skills/woz-kb/SKILL.md)).
+
+## Inferred implementation assets
+
+**INFERRED:** native query parsers, `libpg-query.wasm`, tree-sitter grammars, PDF extraction, and syntax-checker chunks likely support structural search/SQL parsing/document extraction. Obfuscated linkage prevents a confident component-to-artifact map.
+
+## Evidence
+
+- `.mcp.json:2-16`, `codex/wozcode/.mcp.json:2-15` — host boot paths.
+- `agents/*.md` — policy boundaries.
+- `hooks/hooks.json:2-115` — Claude event integration.
+- `servers/code-server.js:3` — bundled server/tool registration.
+
+## Related
+
+[Runtime and data flow](runtime-data-flow.md) · [Agents and commands](agents-commands.md) · [Configuration, auth, and telemetry](configuration-auth-telemetry.md)

--- a/docs/deepwiki/configuration-auth-telemetry.md
+++ b/docs/deepwiki/configuration-auth-telemetry.md
@@ -1,0 +1,43 @@
+---
+id: configuration-auth-telemetry
+importance: high
+filePaths: [README.md, .mcp.json, codex/wozcode/.mcp.json, hooks/hooks.json, skills/woz/SKILL.md, skills/woz-feedback/SKILL.md, skills/woz-kb/SKILL.md, codex/wozcode/skills/woz-login/SKILL.md, codex/wozcode/.codex-plugin/plugin.json, codex/wozcode/hooks/hooks.json]
+relatedPages: [runtime-data-flow, testing-operations, risks-limitations]
+---
+
+# Configuration, Authentication, and Telemetry
+
+**Summary.** **OBSERVED:** Claude settings live under `~/.claude/settings.json`; the MCP server is always loaded with PostHog enabled and a US-region client token in environment configuration ([`README.md:78-95`](../../README.md), [`.mcp.json:2-16`](../../.mcp.json)). Broad hooks make bootstrap, reviewer, and telemetry processing pervasive across a session ([`hooks/hooks.json:3-113`](../../hooks/hooks.json)).
+
+## Settings
+
+The README documents attribution, status-line session/lifetime/tips toggles, and spinner verbs, all defaulting on ([`README.md:78-95`](../../README.md)). The consolidated skill adds runtime-gated reviewer/KB settings, recall indexing, menu-bar/LaunchAgent behavior, fallback agent selection, and `alwaysLoadTools`; the latter only changes behavior on the next launch ([`skills/woz/SKILL.md:121-180`](../../skills/woz/SKILL.md)).
+
+## Authentication paths
+
+- **Browser login:** preferred; credentials are stored and refreshed automatically ([`README.md:32-48`](../../README.md)). Exact storage protection is **UNVERIFIED**.
+- **API key:** the skill calls it password-equivalent and recommends stdin; CI can use `WOZCODE_API_KEY` ([`skills/woz/SKILL.md:48-78`](../../skills/woz/SKILL.md)).
+- **Token JSON:** documented as a `--token` argument for headless login ([`skills/woz/SKILL.md:80-97`](../../skills/woz/SKILL.md), [`codex/wozcode/skills/woz-login/SKILL.md:29-47`](../../codex/wozcode/skills/woz-login/SKILL.md)). **INFERRED risk:** access/refresh tokens can enter shell history, process listings, and agent transcripts.
+
+## Telemetry and data boundaries
+
+**OBSERVED:** Both Claude and Codex MCP configs enable PostHog and embed a project ingestion token/US region ([`.mcp.json:10-15`](../../.mcp.json), [`codex/wozcode/.mcp.json:7-12`](../../codex/wozcode/.mcp.json)). Claude telemetry hooks run after every tool and on stop/subagent/compact events ([`hooks/hooks.json:52-113`](../../hooks/hooks.json)). Feedback includes session id, anonymous id unless opted out, OS/architecture/Node version, and logged-in email ([`skills/woz-feedback/SKILL.md:17-35`](../../skills/woz-feedback/SKILL.md)).
+
+The KB distinguishes company organization data, repository code/PR history, and personal notes, with remote provider behavior documented as the normal path ([`skills/woz-kb/SKILL.md:94-108`](../../skills/woz-kb/SKILL.md), [`skills/woz-kb/SKILL.md:143-151`](../../skills/woz-kb/SKILL.md)).
+
+## Unverified questions
+
+- Credential file path, permissions, encryption/keychain use, refresh rotation, and revocation.
+- Exact telemetry endpoints, event schemas, content redaction, buffering, retry, and retention.
+- KB tenant isolation, retention, repository-content filtering, and deletion controls.
+- Whether the Codex hooks file is activated: the manifest declares skills/MCP but does not explicitly reference hooks ([`codex/wozcode/.codex-plugin/plugin.json:8-10`](../../codex/wozcode/.codex-plugin/plugin.json), [`codex/wozcode/hooks/hooks.json:1-35`](../../codex/wozcode/hooks/hooks.json)).
+
+## Evidence
+
+- `.mcp.json:2-16`, `codex/wozcode/.mcp.json:2-15` — process environment.
+- `hooks/hooks.json:3-113` — telemetry/reviewer/session frequency.
+- `skills/woz/SKILL.md:48-180` — auth and settings behavior.
+
+## Related
+
+[Runtime and data flow](runtime-data-flow.md) · [Testing and operations](testing-operations.md) · [Risks and limitations](risks-limitations.md)

--- a/docs/deepwiki/getting-started.md
+++ b/docs/deepwiki/getting-started.md
@@ -1,0 +1,39 @@
+---
+id: getting-started
+importance: medium
+filePaths: [README.md, skills/woz/SKILL.md, codex/wozcode/.codex-plugin/plugin.json, codex/wozcode/skills/woz-update/SKILL.md]
+relatedPages: [overview, configuration-auth-telemetry, testing-operations]
+---
+
+# Getting Started
+
+**Summary.** **OBSERVED:** Claude installation is marketplace-driven, requires a restart, and uses the `woz:code` badge as the visible activation check ([`README.md:5-30`](../../README.md)). A Woz account is required for tool use; browser login is the preferred path and credentials are persisted/refreshed ([`README.md:32-48`](../../README.md)).
+
+## Claude install and verification
+
+1. Run `/plugin marketplace add WithWoz/wozcode-plugin` and `/plugin install woz@wozcode-marketplace` ([`README.md:7-14`](../../README.md)).
+2. Restart with `claude` ([`README.md:16-22`](../../README.md)).
+3. Confirm the `woz:code` badge, then run `/woz login` or the legacy `/woz-login` alias ([`README.md:24-40`](../../README.md), [`skills/woz/SKILL.md:30-47`](../../skills/woz/SKILL.md)).
+
+For headless use, the README documents copying token JSON from the browser success page into a CLI argument ([`README.md:42-48`](../../README.md)). See [Configuration, auth, and telemetry](configuration-auth-telemetry.md) before using that path because command-line tokens can leak through history or process inspection.
+
+## Management
+
+- Disable, enable, or remove through Claude's plugin commands ([`README.md:97-103`](../../README.md)).
+- Update via `/woz update`; the documented recovery path refreshes the marketplace, reinstalls the plugin, and clears update flags ([`README.md:105-122`](../../README.md)).
+- Launch explicitly with `claude --agent woz:code` for debugging ([`README.md:124-130`](../../README.md)).
+- Conductor integration uses the generated `wozcode conductor` executable; only Search and Edit are explicitly claimed to work there ([`README.md:132-148`](../../README.md)).
+
+## Codex
+
+**OBSERVED:** The nested Codex plugin declares skills and its MCP server, but this repository's README does not document a complete initial Codex install flow ([`codex/wozcode/.codex-plugin/plugin.json:2-10`](../../codex/wozcode/.codex-plugin/plugin.json)). Its update command uses `npx @wozcode/codex update` ([`codex/wozcode/skills/woz-update/SKILL.md:7-15`](../../codex/wozcode/skills/woz-update/SKILL.md)).
+
+## Evidence
+
+- `README.md:5-48` — install, restart, verify, login.
+- `README.md:97-148` — lifecycle management and Conductor.
+- `skills/woz/SKILL.md:30-116` — consolidated auth/status commands.
+
+## Related
+
+[Overview](overview.md) · [Configuration, auth, and telemetry](configuration-auth-telemetry.md) · [Testing and operations](testing-operations.md)

--- a/docs/deepwiki/overview.md
+++ b/docs/deepwiki/overview.md
@@ -1,0 +1,33 @@
+---
+id: overview
+importance: high
+filePaths: [README.md, .claude-plugin/plugin.json, codex/wozcode/.codex-plugin/plugin.json, package.json, codex/wozcode/package.json, servers/code-server.js]
+relatedPages: [getting-started, architecture, risks-limitations]
+---
+
+# Overview
+
+**Summary.** **OBSERVED:** WOZCODE is a Claude Code plugin that replaces built-in file operations with four MCP tools intended to reduce round trips and token usage ([`README.md:1-3`](../../README.md), [`README.md:50-61`](../../README.md)). The repository ships a Claude marketplace plugin plus a nested Codex variant, with executable code already bundled rather than maintained here as ordinary source modules.
+
+## What ships
+
+- **Claude surface:** marketplace/plugin manifests, `woz:code`, `woz:code-free`, `woz:explore`, a Node MCP server, lifecycle hooks, command skills, reviewer/KB/router utilities, and prebuilt assets ([`.claude-plugin/marketplace.json:2-20`](../../.claude-plugin/marketplace.json), [`agents/code.md:1-6`](../../agents/code.md), [`hooks/hooks.json:2-115`](../../hooks/hooks.json)).
+- **Codex surface:** a separately packaged plugin with its own agents, skills, server, hooks, chunks, grammars, and native parser ([`codex/wozcode/.codex-plugin/plugin.json:2-10`](../../codex/wozcode/.codex-plugin/plugin.json), [`codex/wozcode/.mcp.json:2-15`](../../codex/wozcode/.mcp.json)).
+- **Public capability:** Search, Edit, SQL introspection, past-session Recall, cost reporting, authentication/settings, benchmarking, deep review, and organization/repository knowledge operations ([`agents/code.md:2-5`](../../agents/code.md), [`skills/woz/SKILL.md:2-24`](../../skills/woz/SKILL.md), [`skills/woz-kb/SKILL.md:7-21`](../../skills/woz-kb/SKILL.md)).
+
+## Repository character
+
+**OBSERVED:** The root and nested runtime manifests only declare JavaScript module mode; they provide no dependency graph or build/test scripts ([`package.json:1-3`](../../package.json), [`codex/wozcode/package.json:1-3`](../../codex/wozcode/package.json)). Most production entrypoints are one-to-three physical lines of bundled/obfuscated JavaScript, while native `.node` modules and tree-sitter/SQL WASM are committed as artifacts.
+
+**INFERRED:** This is a release artifact repository or marketplace payload, not the authoritative development source. Architecture can be mapped reliably at the integration boundary, but internal algorithms cannot be audited to source-level confidence from this tree alone.
+
+## Evidence
+
+- `README.md:1-76` — product and user surface.
+- `.claude-plugin/plugin.json:2-8` — Claude identity/version.
+- `codex/wozcode/.codex-plugin/plugin.json:2-10` — Codex identity/version and declared resources.
+- `servers/code-server.js:3` — bundled MCP implementation anchor.
+
+## Related
+
+[Getting started](getting-started.md) · [Architecture](architecture.md) · [Risks and limitations](risks-limitations.md)

--- a/docs/deepwiki/risks-limitations.md
+++ b/docs/deepwiki/risks-limitations.md
@@ -1,0 +1,57 @@
+---
+id: risks-limitations
+importance: high
+filePaths: [servers/code-server.js, .claude-plugin/plugin.json, codex/wozcode/.codex-plugin/plugin.json, .mcp.json, hooks/hooks.json, skills/woz/SKILL.md, codex/wozcode/skills/woz-update/SKILL.md, codex/wozcode/skills/woz-benchmark/SKILL.md, package.json, LICENSE]
+relatedPages: [overview, configuration-auth-telemetry, testing-operations]
+---
+
+# Risks and Limitations
+
+**Summary.** The dominant architectural risk is not a proven defect but an assurance gap: privileged, network-capable code is shipped as obfuscated bundles plus native/WASM artifacts without its source/build/test/provenance chain. Default-on telemetry, argv token login, mutable update channels, and Claude/Codex version drift deserve focused follow-up.
+
+## Observed risks
+
+| Area | Evidence | Consequence |
+|---|---|---|
+| Reviewability | Production entrypoints collapse into one-to-three obfuscated lines, e.g. [`servers/code-server.js:3`](../../servers/code-server.js) | Internal behavior and redaction are difficult to independently audit |
+| Version parity | Claude `0.3.87` vs Codex `0.3.70` ([`.claude-plugin/plugin.json:2-8`](../../.claude-plugin/plugin.json), [`codex/wozcode/.codex-plugin/plugin.json:2-10`](../../codex/wozcode/.codex-plugin/plugin.json)) | Host behavior and safety guidance can drift |
+| Telemetry surface | Default-on MCP environment plus hooks after every tool/stop/compact ([`.mcp.json:10-15`](../../.mcp.json), [`hooks/hooks.json:52-113`](../../hooks/hooks.json)) | Broad event collection surface; payload details are opaque |
+| Credential handling | Token JSON passed with `--token` ([`skills/woz/SKILL.md:80-97`](../../skills/woz/SKILL.md)) | Shell history/process/transcript exposure |
+| Update trust | Mutable marketplace/npm update paths without documented hashes/signatures ([`skills/woz/SKILL.md:182-222`](../../skills/woz/SKILL.md), [`codex/wozcode/skills/woz-update/SKILL.md:7-15`](../../codex/wozcode/skills/woz-update/SKILL.md)) | Mispublication or channel compromise reaches executable code |
+| Verification | No first-party scripts/CI/lockfile/SBOM/checksum manifest ([`package.json:1-3`](../../package.json)) | Weak reproducibility and vulnerability-response evidence |
+| License | Proprietary, Terms-of-Service-bound distribution ([`LICENSE:1`](../../LICENSE)) | Source/audit expectations differ from an open-source repo |
+
+## Inferred risks
+
+- Broad hooks plus remote-default knowledge/feedback features may cross sensitive metadata or code boundaries; exact capture and retention remain unknown.
+- Vendored native/WASM/browser assets without visible attestations weaken supply-chain verification.
+- The older Codex benchmark's hard-reset workflow can destroy work if its clean-tree precondition is bypassed or races with edits ([`codex/wozcode/skills/woz-benchmark/SKILL.md:60-68`](../../codex/wozcode/skills/woz-benchmark/SKILL.md)).
+- A wildcard `Bash(node *)` frequent-path permission is broader than the skill's “least privilege” narrative; actual host enforcement is **UNVERIFIED** ([`skills/woz/SKILL.md:1-6`](../../skills/woz/SKILL.md), [`skills/woz/SKILL.md:28`](../../skills/woz/SKILL.md)).
+
+## Open, unverified items
+
+1. Authoritative source repository and exact source revision for each bundled file.
+2. Reproducible build, signing, checksums, SBOM, and vulnerability-scanning pipeline.
+3. Credential storage/encryption and token revocation/rotation behavior.
+4. Telemetry schemas, redaction, prompt/file-content policy, retention, and opt-out verification.
+5. KB tenancy, retention, filtering, and deletion controls.
+6. Whether Codex hook discovery is automatic despite not being declared in its manifest.
+7. Whether every committed native/WASM artifact is verified before load.
+
+## DeepWiki limitations
+
+- Mode A uses simulated retrieval rather than embeddings/FAISS; no persistent index exists.
+- Runtime probing was limited to harmless MCP initialization and tool listing; no auth, write, database, update, reviewer, or network flow was executed.
+- Generated bundles were not deobfuscated exhaustively. Claims about internal algorithms remain **UNVERIFIED** unless surfaced through a manifest, skill, config, or runtime schema.
+- Vendored dependencies, binary internals, and every generated chunk were intentionally not scanned line-by-line.
+
+## Evidence
+
+- `servers/code-server.js:3` — opaque primary runtime.
+- `.mcp.json:10-15`, `hooks/hooks.json:52-113` — telemetry surface.
+- `skills/woz/SKILL.md:80-97,182-222` — token/update paths.
+- `package.json:1-3` — absent build/test metadata.
+
+## Related
+
+[Overview](overview.md) · [Configuration, auth, and telemetry](configuration-auth-telemetry.md) · [Testing and operations](testing-operations.md)

--- a/docs/deepwiki/runtime-data-flow.md
+++ b/docs/deepwiki/runtime-data-flow.md
@@ -1,0 +1,71 @@
+---
+id: runtime-data-flow
+importance: high
+filePaths: [.mcp.json, servers/code-server.js, hooks/hooks.json, agents/explore.md, skills/woz/SKILL.md, skills/woz-recall/SKILL.md, scripts/router-config.jsonc]
+relatedPages: [architecture, agents-commands, configuration-auth-telemetry]
+---
+
+# Runtime and Data Flow
+
+**Summary.** **OBSERVED:** The primary work path is host → selected agent → MCP stdio server → Search/Edit/Recall/Sql. Session, reviewer, and telemetry hooks form lifecycle side paths; a configurable router can redirect model transport ([`.mcp.json:2-16`](../../.mcp.json), [`hooks/hooks.json:3-113`](../../hooks/hooks.json), [`scripts/router-config.jsonc:492-624`](../../scripts/router-config.jsonc)).
+
+## Request flow
+
+**INFERRED diagram, with observed edges:**
+
+```mermaid
+flowchart TD
+  U[User prompt] --> H[Claude Code / Codex]
+  H --> A{Agent selection}
+  A -->|default| C[woz:code]
+  A -->|cap exhausted| F[woz:code-free]
+  C -->|complex lookup| E[woz:explore]
+  C --> M[MCP stdio server]
+  E --> M
+  M --> S[Search]
+  M --> X[Edit]
+  M --> Q[Sql]
+  M --> R[Recall]
+  S --> Repo[(Repository / docs)]
+  X --> Repo
+  Q --> Data[(Database)]
+  R --> History[(Claude sessions)]
+  H -. events .-> K[Session / reviewer / telemetry]
+  C -. optional .-> Router[Model router]
+```
+
+## Tool behavior
+
+A harmless MCP `initialize` plus `tools/list` probe observed four tools from [`servers/code-server.js:3`](../../servers/code-server.js):
+
+- **Search:** combined discovery, content search, file/image/PDF reads, and JavaScript/TypeScript summaries/importer analysis.
+- **Edit:** batched fuzzy replacements, creation/overwrite, and notebook cell actions.
+- **Recall:** semantic lookup over prior Claude sessions; its skill distinguishes enabled and disabled behavior ([`skills/woz-recall/SKILL.md:6-18`](../../skills/woz-recall/SKILL.md)).
+- **Sql:** schema discovery, lint/connect/query operations for PostgreSQL, MySQL, and SQLite.
+
+These schemas are runtime-observed; their readable source definitions are not present separately from the bundle.
+
+## Agent and review flow
+
+The main agent delegates sufficiently complex read-only scans to `woz:explore`, which is instructed to return dense path/line results in 3–5 calls and parallelize independent searches ([`README.md:54-61`](../../README.md), [`agents/explore.md:10-18`](../../agents/explore.md), [`agents/explore.md:37-50`](../../agents/explore.md)). Deep review fans out seven narrow personas, then runs a sequential wide-lens pass using their findings and KB context ([`skills/woz/SKILL.md:244-280`](../../skills/woz/SKILL.md)).
+
+## Hook side paths
+
+- `session-hook.js`: session start, prompt submit, pre-tool, and stop failure ([`hooks/hooks.json:3-40`](../../hooks/hooks.json), [`hooks/hooks.json:84-91`](../../hooks/hooks.json)).
+- `reviewer-hook.js`: prompt submit and after Woz Edit ([`hooks/hooks.json:22-29`](../../hooks/hooks.json), [`hooks/hooks.json:42-50`](../../hooks/hooks.json)).
+- `session-telemetry-hook.js`: every post-tool, subagent/normal stop, and pre/post compact ([`hooks/hooks.json:52-113`](../../hooks/hooks.json)).
+
+## Optional router
+
+**OBSERVED:** router presets map Claude tiers to provider models and rewrite Codex/Azure tool rules toward Woz Search/Edit ([`scripts/router-config.jsonc:19-38`](../../scripts/router-config.jsonc), [`scripts/router-config.jsonc:492-624`](../../scripts/router-config.jsonc)). **INFERRED:** the router daemon is an optional model transport/control plane, not required for core MCP file operations.
+
+## Evidence
+
+- `.mcp.json:2-16` — eager MCP process.
+- `servers/code-server.js:3` — bundled registration/transport anchor.
+- `agents/explore.md:2-50` — delegation contract.
+- `hooks/hooks.json:3-113` — lifecycle paths.
+
+## Related
+
+[Architecture](architecture.md) · [Agents and commands](agents-commands.md) · [Configuration, auth, and telemetry](configuration-auth-telemetry.md)

--- a/docs/deepwiki/testing-operations.md
+++ b/docs/deepwiki/testing-operations.md
@@ -1,0 +1,49 @@
+---
+id: testing-operations
+importance: medium
+filePaths: [README.md, package.json, standalone/package.json, skills/woz/SKILL.md, skills/woz-kb/SKILL.md, codex/wozcode/skills/woz-benchmark/SKILL.md, codex/wozcode/skills/woz-update/SKILL.md, browsers.json]
+relatedPages: [getting-started, configuration-auth-telemetry, risks-limitations]
+---
+
+# Testing and Operations
+
+**Summary.** **OBSERVED:** This distribution contains no first-party build, lint, or test scripts, no CI configuration, and no lockfile/SBOM/checksum manifest. Its user-facing verification mechanisms are live plugin checks, comparison benchmarks, reviewer backtests, and update/reinstall flows rather than repository-local tests ([`package.json:1-3`](../../package.json), [`skills/woz/SKILL.md:289-379`](../../skills/woz/SKILL.md)).
+
+## Verification surfaces
+
+- **Activation:** restart Claude and confirm the `woz:code` badge ([`README.md:16-30`](../../README.md)).
+- **Benchmark:** clone a pinned remote SHA into a scratch directory and run each prompt twice, capped at 15 turns ([`skills/woz/SKILL.md:310-355`](../../skills/woz/SKILL.md)). This avoids mutating the user's checkout.
+- **Reviewer tuning/backtest:** use fresh per-PR clones, remove origin/disable pushes, strip GitHub tokens, sandbox HOME, and write reports under `.wozcode/backtests` ([`skills/woz-kb/SKILL.md:69-77`](../../skills/woz-kb/SKILL.md)).
+
+**OBSERVED drift:** older Codex benchmark instructions operate on a clean target and describe `git reset --hard` between runs ([`codex/wozcode/skills/woz-benchmark/SKILL.md:7-16`](../../codex/wozcode/skills/woz-benchmark/SKILL.md), [`codex/wozcode/skills/woz-benchmark/SKILL.md:60-68`](../../codex/wozcode/skills/woz-benchmark/SKILL.md)). Treat that workflow as materially more destructive than the current Claude benchmark.
+
+## Update operations
+
+Claude update follows mutable marketplace names, with an HTTPS repository fallback but no documented commit/hash/signature verification ([`skills/woz/SKILL.md:182-222`](../../skills/woz/SKILL.md), [`README.md:105-122`](../../README.md)). Codex uses unversioned `npx @wozcode/codex update` ([`codex/wozcode/skills/woz-update/SKILL.md:7-15`](../../codex/wozcode/skills/woz-update/SKILL.md)).
+
+## Shipped platform assets
+
+- Query-parser native modules for Darwin arm64/x64 and Linux x64/musl x64 under `build/Release/`.
+- Tree-sitter grammar WASM and `libpg-query.wasm` under `grammars/` and `chunks/`.
+- Browser revision metadata pins Chromium, Firefox, WebKit, ffmpeg, and platform overrides ([`browsers.json:4-68`](../../browsers.json)).
+- Vendored dependencies include `node-pty`, AJV, and a local canvas stub; provenance/checksum verification is not documented.
+
+## Recommended release gates
+
+These are **recommendations**, not observed repository behavior:
+
+1. Publish the authoritative source revision and reproducible build instructions for every release artifact.
+2. Add CI smoke tests for MCP initialize/tools-list and representative Search/Edit/Sql/Recall schemas.
+3. Add lockfiles, SBOM, checksums/signatures, and native/WASM provenance.
+4. Align Claude/Codex versions and benchmark safety semantics before publication.
+
+## Evidence
+
+- `package.json:1-3`, `standalone/package.json:1-3` — no scripts/dependencies.
+- `skills/woz/SKILL.md:289-379` — current benchmark contract.
+- `skills/woz-kb/SKILL.md:69-77` — backtest sandbox contract.
+- `browsers.json:4-68` — pinned runtime assets.
+
+## Related
+
+[Getting started](getting-started.md) · [Configuration, auth, and telemetry](configuration-auth-telemetry.md) · [Risks and limitations](risks-limitations.md)


### PR DESCRIPTION
## Summary

- add an evidence-linked DeepWiki for the Claude and Codex plugin surfaces
- document architecture, runtime data flows, agents, configuration, authentication, and telemetry
- record operational verification, supply-chain risks, and explicitly unverified behavior

## Test Plan

- [x] verify all relative Markdown links resolve
- [x] verify fenced code blocks are balanced
- [x] run git diff --check
- [x] scan the documentation for common credential patterns

Generated with [Devin](https://cli.devin.ai/docs)